### PR TITLE
feat(tools): параметры неинтерактивных вызовов (sha, extensions, frameworks, execute, command)

### DIFF
--- a/docs/tool-parameters.md
+++ b/docs/tool-parameters.md
@@ -9,6 +9,25 @@
 | `ibConnection` | Явная строка подключения к ИБ. Без неё берётся значение из файла настроек, иначе `/F./build/ib` |
 | `pathsOverride` | Переопределение стандартных каталогов проекта (см. ниже) |
 | `wait` | Ждать завершения и вернуть `{ success, exitCode, stdout, stderr, artifact, durationMs }`. По умолчанию `false`: команда уходит в терминал, управление возвращается сразу |
+| `sha` | SHA коммита для `configuration_loadIncFromSrc`: изменения загружаются от него до текущего состояния (пустая строка — полная загрузка). Без параметра команда запросит ввод в UI |
+| `extensions` | Явный список имён расширений для `extensions_*`; без него используется сохранённый выбор проекта (или все расширения) |
+| `frameworks` | Включаемые тестовые фреймворки для `testing_configure`: `vanessa`, `xunit`, `yaxunit`, `onescript`, `onebdd`. Перечисленные включаются, остальные выключаются, недостающие каталоги создаются |
+| `execute` | Путь к внешней обработке/отчёту (.epf/.erf) для `enterprise_run` (`vrunner run --execute`) |
+| `command` | Строка параметров запуска `/C` для `enterprise_run` (`vrunner run --command`) |
+
+## Запуск обработок: enterprise_run
+
+Служебные шаги инициализации (загрузка фикстур, служебные EPF) выполняются инструментом `enterprise_run`; нужен хотя бы один из `execute`/`command`:
+
+```jsonc
+{
+  "projectPath": "C:/work/erp",
+  "execute": "./build/out/epf/ЗагрузкаФикстур.epf",
+  "command": "Путь=./fixtures/Константы.xml;ЗавершитьРаботуСистемы",
+  "settingsFile": "tools/vrunner.init.json",
+  "wait": true
+}
+```
 
 ## Профили запуска и settingsFile
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,40 @@ const baseParamsShape = {
 		})
 		.optional()
 		.describe("Переопределение стандартных путей src/cf, build/out, src/cfe, src/epf, src/erf относительно projectPath"),
+	sha: z
+		.string()
+		.optional()
+		.describe(
+			"SHA коммита для инкрементальной загрузки конфигурации (cfg_loadIncFromSrc). " +
+			"Пустая строка — полная загрузка. Без параметра команда запросит ввод в UI."
+		),
+	extensions: z
+		.array(z.string())
+		.optional()
+		.describe(
+			"Явный список имён расширений для команд extensions_*. " +
+			"Без него используется сохранённый выбор проекта (или все расширения)."
+		),
+	frameworks: z
+		.array(z.string())
+		.optional()
+		.describe(
+			"Ключи включаемых тестовых фреймворков для testing_configure: " +
+			"vanessa, xunit, yaxunit, onescript, onebdd. Остальные выключаются."
+		),
+	execute: z
+		.string()
+		.optional()
+		.describe(
+			"Путь к внешней обработке/отчёту (.epf/.erf) для enterprise_run (vrunner run --execute)."
+		),
+	command: z
+		.string()
+		.optional()
+		.describe(
+			"Строка параметров запуска /C для enterprise_run (vrunner run --command), " +
+			"например 'Путь=./fixtures/Константы.xml;ЗавершитьРаботуСистемы'."
+		),
 	wait: z
 		.boolean()
 		.optional()
@@ -88,7 +122,17 @@ async function runTool(
 	try {
 		const result = await ipcClient.executeCommand(
 			commandId,
-			[{ wait, settingsFile: params.settingsFile, ibConnection: params.ibConnection, pathsOverride: params.pathsOverride }],
+			[{
+				wait,
+				settingsFile: params.settingsFile,
+				ibConnection: params.ibConnection,
+				pathsOverride: params.pathsOverride,
+				sha: params.sha,
+				extensions: params.extensions,
+				frameworks: params.frameworks,
+				execute: params.execute,
+				command: params.command,
+			}],
 			params.projectPath,
 			timeoutMs
 		);


### PR DESCRIPTION
## Что сделано

Парный PR к yellow-hammer/vscode-1c-platform-tools#234: схема инструментов MCP дополнена параметрами, которые расширение теперь понимает в неинтерактивных вызовах.

| Параметр | Инструменты | Назначение |
|---|---|---|
| `sha` | `configuration_loadIncFromSrc` | SHA коммита для инкрементальной загрузки; пустая строка — полная загрузка. Раньше команда требовала ввода в UI и `wait` отклонялся |
| `extensions` | `extensions_*` | Явный список имён расширений вместо сохранённого выбора проекта |
| `frameworks` | `testing_configure` | Включаемые фреймворки; с ним команда работает без визарда и поддерживает `wait: true` |
| `execute`, `command` | `enterprise_run` | Путь к EPF/ERF и строка `/C` для нового инструмента запуска обработок (`vrunner run`) |

Все параметры опциональны, значения пробрасываются в флаги IPC первым аргументом команды. Документация `docs/tool-parameters.md` дополнена, добавлен раздел про `enterprise_run` со сценарием загрузки фикстур.

## Проверка

- `npm run build` — чисто
- `npm test` — 24 passing

Работает в паре с yellow-hammer/vscode-1c-platform-tools#234: без обновлённого расширения новые параметры просто игнорируются (совместимо), с ним — реализуют #27 и #28.

Закрывает #27 и #28 (закрыть вручную после мержа обоих PR: русское слово GitHub не понимает).
