### PR TITLE
feat(session): параметры сеансов под vanessa-runner 3

### DIFF
--- a/src/toolParams.ts
+++ b/src/toolParams.ts
@@ -114,20 +114,51 @@ const sessionShape = {
 		.describe("Время окончания блокировки (только vanessa-runner 2.x)"),
 } as const;
 
-/** Завершение сеансов: отбор и режим отбора. */
-const sessionKillShape = {
+/** Отбор сеансов: общий для завершения, проверки отсутствия и списка. */
+const sessionFilterShape = {
 	sessionFilter: z
 		.string()
 		.optional()
-		.describe("Отбор сеансов, например appid=Designer|name=Администратор (только vanessa-runner 2.x)"),
+		.describe("Отбор сеансов, например appid=Designer|name=Администратор; значения через точку с запятой"),
 	sessionFilterMode: z
 		.string()
 		.optional()
-		.describe("Режим отбора: ONLY, OFF, EXCEPT, DEFAULT, ALL (только vanessa-runner 2.x)"),
+		.describe("Режим отбора: ONLY, OFF, EXCEPT; DEFAULT и ALL - только vanessa-runner 2.x"),
+} as const;
+
+/** Завершение сеансов: блокировка и ожидание завершения. */
+const sessionKillShape = {
+	...sessionFilterShape,
 	keepSessionsUnlocked: z
 		.boolean()
 		.optional()
 		.describe("Не запрещать начало новых сеансов при их завершении"),
+	sessionRetry: z
+		.number()
+		.optional()
+		.describe("Число попыток добить зависшие сеансы, по умолчанию 3 (только vanessa-runner 3.x)"),
+	sessionTimeout: z
+		.number()
+		.optional()
+		.describe("Ожидание завершения сеансов в секундах; при нём число попыток не используется (только vanessa-runner 3.x)"),
+} as const;
+
+/** Проверка отсутствия сеансов: отбор и ожидание. */
+const sessionClosedShape = {
+	...sessionFilterShape,
+	sessionTimeout: z
+		.number()
+		.optional()
+		.describe("Ждать освобождения базы столько секунд, проверяя каждые 3 секунды (только vanessa-runner 3.x)"),
+} as const;
+
+/** Список сеансов: отбор и вывод соединений. */
+const sessionListShape = {
+	...sessionFilterShape,
+	sessionConnections: z
+		.boolean()
+		.optional()
+		.describe("Дополнительно показать соединения информационной базы, включая зависшие без сеанса"),
 } as const;
 
 /** Запуск цепочки шагов из .1cpt/pipelines.json. */
@@ -203,11 +234,14 @@ export function paramsForCommand(commandId: string): ToolParamsShape {
 	if (commandId.startsWith("1c-platform-tools.session.")) {
 		Object.assign(shape, sessionShape);
 	}
-	if (
-		commandId === "1c-platform-tools.session.kill" ||
-		commandId === "1c-platform-tools.session.checkClosed"
-	) {
+	if (commandId === "1c-platform-tools.session.kill") {
 		Object.assign(shape, sessionKillShape);
+	}
+	if (commandId === "1c-platform-tools.session.checkClosed") {
+		Object.assign(shape, sessionClosedShape);
+	}
+	if (commandId === "1c-platform-tools.session.list") {
+		Object.assign(shape, sessionListShape);
 	}
 	if (commandId === "1c-platform-tools.pipelines.run") {
 		Object.assign(shape, pipelineShape);

--- a/test/toolParams.test.ts
+++ b/test/toolParams.test.ts
@@ -76,6 +76,21 @@ describe("paramsForCommand: сеансы и цепочки", () => {
 		assert.ok(kill.includes("keepSessionsUnlocked"), "нет отказа от блокировки");
 	});
 
+	it("завершение, проверка и список сеансов различаются параметрами", () => {
+		const kill = Object.keys(paramsForCommand("1c-platform-tools.session.kill"));
+		assert.ok(kill.includes("sessionRetry"), "нечем задать число попыток");
+		assert.ok(kill.includes("sessionTimeout"), "нечем задать ожидание");
+
+		const closed = Object.keys(paramsForCommand("1c-platform-tools.session.checkClosed"));
+		assert.ok(closed.includes("sessionTimeout"), "нечем подождать освобождения базы");
+		assert.ok(!closed.includes("keepSessionsUnlocked"), "проверка сеансы не завершает");
+
+		const list = Object.keys(paramsForCommand("1c-platform-tools.session.list"));
+		assert.ok(list.includes("sessionConnections"), "нечем запросить соединения");
+		assert.ok(list.includes("sessionFilter"), "список тоже умеет отбор");
+		assert.ok(!list.includes("keepSessionsUnlocked"), "список ничего не завершает");
+	});
+
 	it("запуск цепочки требует идентификатор пайплайна", () => {
 		const shape = paramsForCommand("1c-platform-tools.pipelines.run");
 		assert.ok("pipeline" in shape, "агенту нечем выбрать цепочку");


### PR DESCRIPTION
Сопровождает yellow-hammer/vscode-1c-platform-tools#262: расширение получило команду списка сеансов и параметры ожидания, агенту нужно их видеть.

- отбор (`sessionFilter`, `sessionFilterMode`) вынесен в общую часть: он одинаков у завершения, проверки отсутствия и списка;
- завершению добавлены `sessionRetry` и `sessionTimeout` - число попыток добить зависшие сеансы и ожидание;
- проверке отсутствия добавлен `sessionTimeout` - ждать освобождения базы;
- у нового `session.list` есть `sessionConnections` и нет параметров завершения.

Описание режима отбора поправлено: `DEFAULT` и `ALL` есть только в 2.x, в 3.x работают `ONLY`, `OFF` и `EXCEPT`.

Тест проверяет, что три команды различаются набором параметров: список ничего не завершает, проверка не блокирует. Прогон - 72 теста, зелёный.