### PR TITLE
fix(tools): убрали команду, которой в расширении нет

### DIFF
--- a/src/toolParams.ts
+++ b/src/toolParams.ts
@@ -225,10 +225,7 @@ export function paramsForCommand(commandId: string): ToolParamsShape {
 	if (commandId === "1c-platform-tools.test.configure") {
 		Object.assign(shape, frameworksShape);
 	}
-	if (
-		commandId === "1c-platform-tools.externalProcessors.run" ||
-		commandId === "1c-platform-tools.run.enterprise"
-	) {
+	if (commandId === "1c-platform-tools.run.enterprise") {
 		Object.assign(shape, enterpriseShape);
 	}
 	if (commandId.startsWith("1c-platform-tools.session.")) {

--- a/test/toolParams.test.ts
+++ b/test/toolParams.test.ts
@@ -48,8 +48,8 @@ describe("paramsForCommand", () => {
 		assert.ok(!keys("1c-platform-tools.build.cf").includes("extensions"));
 	});
 
-	it("запуск обработки в Предприятии получает execute и command", () => {
-		const shape = keys("1c-platform-tools.externalProcessors.run");
+	it("запуск Предприятия получает execute и command: ими открывают обработку", () => {
+		const shape = keys("1c-platform-tools.run.enterprise");
 		assert.ok(shape.includes("execute"));
 		assert.ok(shape.includes("command"));
 	});


### PR DESCRIPTION
Нашёл сверкой списка команд с манифестом расширения перед релизом.

`paramsForCommand` описывала `1c-platform-tools.externalProcessors.run` - такой команды в расширении нет, есть `externalProcessors.build` и `externalProcessors.decompile`, а обработку в Предприятии открывает `run.enterprise` теми же параметрами `execute` и `command`.

Тест проверял ровно эту несуществующую команду, то есть подтверждал работу того, чего нет. Переписан на `run.enterprise`.

Прогон - 72 теста, зелёный.