### PR TITLE
chore(tools): убрали pathsOverride, который ничего не делал

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -48,7 +48,6 @@ export interface ToolParams {
 	wait?: boolean;
 	settingsFile?: string;
 	ibConnection?: string;
-	pathsOverride?: Record<string, string | undefined>;
 	sha?: string;
 	extensions?: string[];
 	profile?: string;
@@ -103,7 +102,6 @@ export async function runTool(
 				wait,
 				settingsFile: params.settingsFile,
 				ibConnection: params.ibConnection,
-				pathsOverride: params.pathsOverride,
 				sha: params.sha,
 				extensions: params.extensions,
 				profile: params.profile,

--- a/src/toolParams.ts
+++ b/src/toolParams.ts
@@ -39,20 +39,6 @@ const settingsShape = {
 		.describe("Явная строка подключения к ИБ. Если не задана, берётся из настроек проекта"),
 } as const;
 
-/** Переопределение каталогов проекта: команды, работающие с исходниками и сборкой. */
-const pathsShape = {
-	pathsOverride: z
-		.object({
-			cf: z.string().optional(),
-			out: z.string().optional(),
-			cfe: z.string().optional(),
-			epf: z.string().optional(),
-			erf: z.string().optional(),
-		})
-		.optional()
-		.describe("Переопределение каталогов src/cf, build/out, src/cfe, src/epf, src/erf относительно projectPath"),
-} as const;
-
 const shaShape = {
 	sha: z
 		.string()
@@ -183,17 +169,6 @@ const WITHOUT_SETTINGS = [
 ];
 
 /** Команды, которым нужны каталоги проекта. */
-const WITH_PATHS = [
-	"1c-platform-tools.configuration.",
-	"1c-platform-tools.build.",
-	"1c-platform-tools.decompile.",
-	"1c-platform-tools.extensions.",
-	"1c-platform-tools.externalProcessors.",
-	"1c-platform-tools.externalReports.",
-	"1c-platform-tools.externalFiles.",
-	"1c-platform-tools.test.",
-	"1c-platform-tools.infobase.",
-];
 
 /** Схема параметров инструмента: общие поля плюс применимые к команде. */
 export type ToolParamsShape = Record<string, z.ZodTypeAny>;
@@ -209,9 +184,6 @@ export function paramsForCommand(commandId: string): ToolParamsShape {
 
 	if (!WITHOUT_SETTINGS.some((prefix) => commandId.startsWith(prefix))) {
 		Object.assign(shape, settingsShape);
-	}
-	if (WITH_PATHS.some((prefix) => commandId.startsWith(prefix))) {
-		Object.assign(shape, pathsShape);
 	}
 	if (commandId === "1c-platform-tools.configuration.loadIncrementFromSrc") {
 		Object.assign(shape, shaShape);

--- a/test/toolParams.test.ts
+++ b/test/toolParams.test.ts
@@ -54,11 +54,6 @@ describe("paramsForCommand", () => {
 		assert.ok(shape.includes("command"));
 	});
 
-	it("каталоги проекта переопределяются там, где идёт работа с исходниками", () => {
-		assert.ok(keys("1c-platform-tools.configuration.loadFromSrc").includes("pathsOverride"));
-		assert.ok(!keys("1c-platform-tools.env.selectProfile").includes("pathsOverride"));
-	});
-
 	it("схема заметно короче прежней общей", () => {
 		assert.ok(keys("1c-platform-tools.env.selectProfile").length <= 3);
 	});


### PR DESCRIPTION
Парная правка к yellow-hammer/vscode-1c-platform-tools#272.

Агенту описывался параметр «Переопределение каталогов src/cf, build/out, src/cfe, src/epf, src/erf относительно projectPath». В расширении он не читался нигде: пути всегда берутся из настроек. То есть агент передавал каталог, получал успех и работу с другим каталогом.

Убрана схема параметров, список команд, которым она подмешивалась, поле в запросе сервера и тест, который проверял наличие этого параметра.

Прогон - 71 тест, зелёный.