### PR TITLE
feat(tools)!: параметры инструмента доходят до команды и имена под новый словарь

### DIFF
--- a/docs/tool-parameters.md
+++ b/docs/tool-parameters.md
@@ -8,11 +8,12 @@
 | `settingsFile` | Файл настроек vanessa-runner относительно `projectPath`. По умолчанию активный профиль проекта (`env.json`) |
 | `ibConnection` | Явная строка подключения к ИБ. Без неё берётся значение из файла настроек, иначе `/F./build/ib` |
 | `pathsOverride` | Переопределение стандартных каталогов проекта (см. ниже) |
-| `sha` | SHA коммита для `configuration_loadIncFromSrc`; пустая строка — полная загрузка |
-| `extensions` | Явный список имён расширений для `extensions_*` и тестовых `test_*Exts`; без него — сохранённый выбор проекта |
+| `sha` | SHA коммита для `cf_loadInc`; пустая строка — полная загрузка |
+| `extensions` | Явный список имён расширений для `cfe_*` и тестовых `test_*Exts`; без него — сохранённый выбор проекта |
+| `updateDb` | Обновить конфигурацию БД (UpdateDBCfg) тем же запуском после загрузки: `cf_load`, `cf_loadFile`, `cf_loadByList`, `cf_loadInc`, `cfe_load`. Без параметра загрузка идёт без обновления, если в настройках проекта не задано иное |
 | `profile` | Имя env-профиля для `env_selectProfile` (id, имя файла или подпись) |
 | `frameworks` | Включаемые тестовые фреймворки для `test_configure` (vanessa, xunit, yaxunit, onescript, onebdd) |
-| `execute`, `command` | Путь к EPF/ERF и строка `/C` для `externalProcs_run` |
+| `execute`, `command` | Путь к EPF/ERF и строка `/C` для `epf_run` |
 | `wait` | Ждать завершения и вернуть `{ success, exitCode, stdout, stderr, tests, artifact, durationMs }`. По умолчанию `true`: без ожидания исход операции неизвестен. `false` — команда уходит в UI-терминал, управление возвращается сразу |
 
 Синхронный вызов ждёт до 30 минут; предел меняется переменной окружения `MCP_1C_WAIT_TIMEOUT_MS` в конфиге MCP. У самого агента бывает свой предел ожидания: если он обрывает долгую операцию, запускайте её с `wait: false` и смотрите ход выполнения в терминале VS Code.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1644,9 +1644,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3182,9 +3182,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
   },
   "type": "module",
   "overrides": {
-    "js-yaml": "^4.3.0",
-    "@hono/node-server": "^2.0.5"
+    "js-yaml": "^4.3.1",
+    "@hono/node-server": "^2.0.5",
+    "brace-expansion": "^5.0.9"
   }
 }

--- a/src/ipcClient.ts
+++ b/src/ipcClient.ts
@@ -245,7 +245,7 @@ export class IpcClient {
 	/**
 	 * Вызывает команду расширения в контексте указанного проекта.
 	 *
-	 * @param commandId — идентификатор команды (например 1c-platform-tools.configuration.loadFromSrc)
+	 * @param commandId — идентификатор команды (например 1c-platform-tools.cf.load)
 	 * @param args — аргументы команды; первым элементом рекомендуется передавать объект с флагами (wait, settingsFile и т.д.)
 	 * @param projectPath — корень проекта 1С; без него расширение работает
 	 *   с открытой папкой VS Code

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,18 +42,17 @@ export interface CommandGateway {
 	): Promise<unknown>;
 }
 
-/** Параметры вызова инструмента: набор полей зависит от команды. */
+/**
+ * Параметры вызова инструмента: набор полей зависит от команды.
+ *
+ * Поля, кроме projectPath и wait, уходят команде расширения как есть, поэтому
+ * новый параметр в схеме инструмента ({@link paramsForCommand}) начинает работать
+ * без правок здесь.
+ */
 export interface ToolParams {
 	projectPath?: string;
 	wait?: boolean;
-	settingsFile?: string;
-	ibConnection?: string;
-	sha?: string;
-	extensions?: string[];
-	profile?: string;
-	frameworks?: string[];
-	execute?: string;
-	command?: string;
+	[option: string]: unknown;
 }
 
 /** Ответ инструмента MCP. */
@@ -94,22 +93,15 @@ export async function runTool(
 ): Promise<ToolResult> {
 	const wait = params.wait ?? true;
 	const timeoutMs = wait ? readWaitTimeout() : TIMEOUT_DEFAULT_MS;
+	// projectPath адресует проект, wait управляет ожиданием; остальное - параметры
+	// самой команды, и они уходят расширению без перечисления по именам.
+	const { projectPath, wait: _wait, ...commandOptions } = params;
 
 	try {
 		const result = await gateway.executeCommand(
 			commandId,
-			[{
-				wait,
-				settingsFile: params.settingsFile,
-				ibConnection: params.ibConnection,
-				sha: params.sha,
-				extensions: params.extensions,
-				profile: params.profile,
-				frameworks: params.frameworks,
-				execute: params.execute,
-				command: params.command,
-			}],
-			params.projectPath,
+			[{ wait, ...commandOptions }],
+			projectPath,
 			timeoutMs
 		);
 		const text = formatCommandResult(result);

--- a/src/toolParams.ts
+++ b/src/toolParams.ts
@@ -165,6 +165,25 @@ const pipelineShape = {
 		),
 } as const;
 
+/** Команды загрузки: применение загруженного к конфигурации БД задаётся вызовом. */
+const LOAD_COMMANDS = [
+	"1c-platform-tools.configuration.loadFromSrc",
+	"1c-platform-tools.configuration.loadFromCf",
+	"1c-platform-tools.configuration.loadFromFilesByList",
+	"1c-platform-tools.configuration.loadIncrementFromSrc",
+	"1c-platform-tools.extensions.loadFromSrc",
+];
+
+const updateDbShape = {
+	updateDb: z
+		.boolean()
+		.optional()
+		.describe(
+			"Обновить конфигурацию БД (UpdateDBCfg) тем же запуском после загрузки. " +
+			"Без параметра загрузка выполняется без обновления, если в настройках проекта не задано иное"
+		),
+} as const;
+
 /** Команды, которым не нужны настройки vanessa-runner. */
 const WITHOUT_SETTINGS = [
 	"1c-platform-tools.env.",
@@ -195,6 +214,9 @@ export function paramsForCommand(commandId: string): ToolParamsShape {
 	}
 	if (commandId === "1c-platform-tools.configuration.loadIncrementFromSrc") {
 		Object.assign(shape, shaShape);
+	}
+	if (LOAD_COMMANDS.includes(commandId)) {
+		Object.assign(shape, updateDbShape);
 	}
 	if (
 		commandId.startsWith("1c-platform-tools.extensions.") ||

--- a/src/toolParams.ts
+++ b/src/toolParams.ts
@@ -188,7 +188,6 @@ const updateDbShape = {
 const WITHOUT_SETTINGS = [
 	"1c-platform-tools.env.",
 	"1c-platform-tools.launch.",
-	"1c-platform-tools.testing.",
 	"1c-platform-tools.dependencies.",
 	"1c-platform-tools.oscript.",
 	"1c-platform-tools.components.",

--- a/src/toolParams.ts
+++ b/src/toolParams.ts
@@ -167,11 +167,11 @@ const pipelineShape = {
 
 /** Команды загрузки: применение загруженного к конфигурации БД задаётся вызовом. */
 const LOAD_COMMANDS = [
-	"1c-platform-tools.configuration.loadFromSrc",
-	"1c-platform-tools.configuration.loadFromCf",
-	"1c-platform-tools.configuration.loadFromFilesByList",
-	"1c-platform-tools.configuration.loadIncrementFromSrc",
-	"1c-platform-tools.extensions.loadFromSrc",
+	"1c-platform-tools.cf.load",
+	"1c-platform-tools.cf.loadFile",
+	"1c-platform-tools.cf.loadByList",
+	"1c-platform-tools.cf.loadIncrement",
+	"1c-platform-tools.cfe.load",
 ];
 
 const updateDbShape = {
@@ -212,14 +212,14 @@ export function paramsForCommand(commandId: string): ToolParamsShape {
 	if (!WITHOUT_SETTINGS.some((prefix) => commandId.startsWith(prefix))) {
 		Object.assign(shape, settingsShape);
 	}
-	if (commandId === "1c-platform-tools.configuration.loadIncrementFromSrc") {
+	if (commandId === "1c-platform-tools.cf.loadIncrement") {
 		Object.assign(shape, shaShape);
 	}
 	if (LOAD_COMMANDS.includes(commandId)) {
 		Object.assign(shape, updateDbShape);
 	}
 	if (
-		commandId.startsWith("1c-platform-tools.extensions.") ||
+		commandId.startsWith("1c-platform-tools.cfe.") ||
 		TEST_EXTENSION_COMMANDS.includes(commandId)
 	) {
 		Object.assign(shape, extensionsShape);

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -158,6 +158,23 @@ describe("createMcpServer", () => {
 		await client.close();
 	});
 
+	it("до команды доходит каждый параметр из схемы инструмента", async () => {
+		// Схема принимала параметры сеансов, цепочек и обновления БД, а до расширения
+		// доходил только перечисленный вручную набор: агент задавал их вхолостую.
+		const gateway = new FakeGateway(DESCRIPTORS);
+		const client = await connect(gateway);
+
+		await client.callTool({
+			name: "configuration_loadIncFromSrc",
+			arguments: { projectPath: "C:/work/erp", sha: "", updateDb: true },
+		});
+
+		const flags = (gateway.calls[0].args?.[0] ?? {}) as Record<string, unknown>;
+		assert.strictEqual(flags.updateDb, true, "параметр команды должен доходить до расширения");
+		assert.ok(!('projectPath' in flags), "projectPath адресует проект, а не команду");
+		await client.close();
+	});
+
 	it("упавшие тесты помечают ответ как неуспешный", async () => {
 		const failing = {
 			success: true,

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -56,7 +56,7 @@ const DESCRIPTORS: CommandDescriptor[] = [
 		supportsWait: true,
 	},
 	{
-		id: "1c-platform-tools.configuration.loadIncrementFromSrc",
+		id: "1c-platform-tools.cf.loadIncrement",
 		title: "Загрузить изменения (git diff)",
 		category: "1C: Конфигурация",
 		supportsWait: true,
@@ -112,7 +112,7 @@ describe("createMcpServer", () => {
 		const { tools } = await client.listTools();
 
 		const xunit = tools.find((tool) => tool.name === "test_xunit");
-		const increment = tools.find((tool) => tool.name === "configuration_loadIncFromSrc");
+		const increment = tools.find((tool) => tool.name === "cf_loadInc");
 		const xunitProps = Object.keys(xunit?.inputSchema.properties ?? {});
 		const incrementProps = Object.keys(increment?.inputSchema.properties ?? {});
 
@@ -145,12 +145,12 @@ describe("createMcpServer", () => {
 		const client = await connect(gateway);
 
 		await client.callTool({
-			name: "configuration_loadIncFromSrc",
+			name: "cf_loadInc",
 			arguments: { projectPath: "C:/work/erp", sha: "HEAD~1" },
 		});
 
 		assert.strictEqual(gateway.calls.length, 1);
-		assert.strictEqual(gateway.calls[0].commandId, "1c-platform-tools.configuration.loadIncrementFromSrc");
+		assert.strictEqual(gateway.calls[0].commandId, "1c-platform-tools.cf.loadIncrement");
 		assert.strictEqual(gateway.calls[0].projectPath, "C:/work/erp");
 		const flags = (gateway.calls[0].args?.[0] ?? {}) as Record<string, unknown>;
 		assert.strictEqual(flags.sha, "HEAD~1");
@@ -165,7 +165,7 @@ describe("createMcpServer", () => {
 		const client = await connect(gateway);
 
 		await client.callTool({
-			name: "configuration_loadIncFromSrc",
+			name: "cf_loadInc",
 			arguments: { projectPath: "C:/work/erp", sha: "", updateDb: true },
 		});
 

--- a/test/toolName.test.ts
+++ b/test/toolName.test.ts
@@ -20,15 +20,15 @@ describe("toolName", () => {
 			"1c-platform-tools.artifacts.decompileConfiguration_fromEditor",
 			"1c-platform-tools.artifacts.decompileExtension_fromEditor",
 			"1c-platform-tools.artifacts.decompileProcessor_fromEditor",
-			"1c-platform-tools.configuration.loadIncrementFromSrc",
-			"1c-platform-tools.configuration.loadFromFilesByList",
-			"1c-platform-tools.configuration.dumpIncrementToSrc",
+			"1c-platform-tools.cf.loadIncrement",
+			"1c-platform-tools.cf.loadByList",
+			"1c-platform-tools.cf.dumpIncrement",
 			"1c-platform-tools.infobase.blockExternalResources",
-			"1c-platform-tools.configuration.loadFromSrc",
-			"1c-platform-tools.configuration.loadFromSrc.init",
-			"1c-platform-tools.extensions.dumpToCfe",
-			"1c-platform-tools.externalProcessors.decompile",
-			"1c-platform-tools.externalReports.decompile",
+			"1c-platform-tools.cf.load",
+			"1c-platform-tools.infobase.initFromSrc",
+			"1c-platform-tools.cfe.unload",
+			"1c-platform-tools.epf.decompileProcessor",
+			"1c-platform-tools.epf.decompileReport",
 		];
 
 		for (const commandId of commandIds) {
@@ -51,10 +51,10 @@ describe("toolName", () => {
 	});
 
 	it("commandId без префикса даёт тот же результат, что и с префиксом (префикс отрезается)", () => {
-		const withPrefix = commandIdToToolName("1c-platform-tools.configuration.loadFromSrc");
-		const withoutPrefix = commandIdToToolName("configuration.loadFromSrc");
+		const withPrefix = commandIdToToolName("1c-platform-tools.cf.load");
+		const withoutPrefix = commandIdToToolName("cf.load");
 		assert.strictEqual(withPrefix, withoutPrefix);
-		assert.strictEqual(withPrefix, "configuration_loadFromSrc");
+		assert.strictEqual(withPrefix, "cf_load");
 	});
 
 	it("применяет аббревиатуры и заменяет точки на подчёркивания", () => {
@@ -134,7 +134,7 @@ describe("uniqueToolName", () => {
 
 	it("запасное имя укладывается в лимит длины", () => {
 		const used = new Set<string>();
-		const longId = "1c-platform-tools.configuration.loadIncrementFromSrcWithVeryLongTail";
+		const longId = "1c-platform-tools.cf.loadIncrementWithVeryLongTail";
 		uniqueToolName(longId, used);
 		const fallback = uniqueToolName(longId, used);
 		assert.ok(

--- a/test/toolParams.test.ts
+++ b/test/toolParams.test.ts
@@ -28,8 +28,8 @@ describe("paramsForCommand", () => {
 	});
 
 	it("инкрементальная загрузка получает sha", () => {
-		assert.ok(keys("1c-platform-tools.configuration.loadIncrementFromSrc").includes("sha"));
-		assert.ok(!keys("1c-platform-tools.configuration.loadFromSrc").includes("sha"));
+		assert.ok(keys("1c-platform-tools.cf.loadIncrement").includes("sha"));
+		assert.ok(!keys("1c-platform-tools.cf.load").includes("sha"));
 	});
 
 	it("выбор профиля получает profile и обходится без настроек прогона", () => {
@@ -50,7 +50,7 @@ describe("paramsForCommand", () => {
 	});
 
 	it("команды расширений конфигурации получают extensions", () => {
-		assert.ok(keys("1c-platform-tools.extensions.build").includes("extensions"));
+		assert.ok(keys("1c-platform-tools.cfe.compile").includes("extensions"));
 		assert.ok(!keys("1c-platform-tools.build.cf").includes("extensions"));
 	});
 


### PR DESCRIPTION
Две правки, обе видны агенту.

## Параметры инструмента доходили не все

`runTool` перечислял поля вручную, а схемы инструментов объявляли больше: `pipeline`, параметры сеансов и таймауты доходили до схемы, но не до расширения. Агент задавал их вхолостую, а `onec_pipelines_run` не получал идентификатор цепочки и возвращал ошибку «пайплайн не найден».

Теперь всё, кроме `projectPath` и `wait`, уходит команде как есть, поэтому новый параметр в схеме начинает работать без правок в двух местах. Новый тест падает на прежнем коде и проходит на новом.

## Имена инструментов под новый словарь команд

Парная правка к yellow-hammer/vscode-1c-platform-tools#317: команды расширения переехали в группы `cf`, `cfe`, `epf`, `infobase`, вслед за ними изменились имена инструментов (`cf_load`, `cfe_load`, `epf_compileProc`, `infobase_updateDb`). Сокращения, которым больше нечего сокращать, убраны.

Командам загрузки добавлен `updateDb`: применять ли загруженное к конфигурации БД тем же запуском.

**BREAKING CHANGE**: сохранённые у агента имена вроде `configuration_loadFromSrc` больше не существуют; полный список сервер отдаёт при подключении.

Проверено: 73 теста.
